### PR TITLE
Remove pinned python version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,3 @@ name = "pypi"
 click = "*"
 requests = "*"
 json5 = "*"
-
-[requires]
-python_version = "3.8"


### PR DESCRIPTION
There's no need to use a fixed python version.

Signed-off-by: Stefan Naewe <stefan.naewe@gmail.com>
